### PR TITLE
feat: add testllm terraform suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+.terraform.lock.hcl

--- a/agn.tf
+++ b/agn.tf
@@ -1,0 +1,76 @@
+resource "testllm_test_suite" "agn" {
+  org_id = testllm_organization.org.id
+  name   = "agn"
+}
+
+resource "testllm_test" "agn_simple_hello" {
+  org_id   = testllm_organization.org.id
+  suite_id = testllm_test_suite.agn.id
+  name     = "simple-hello"
+
+  items = [
+    {
+      type    = "message"
+      role    = "user"
+      content = "hi"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "Hi! How are you?"
+    },
+  ]
+}
+
+resource "testllm_test" "agn_simple_state" {
+  org_id   = testllm_organization.org.id
+  suite_id = testllm_test_suite.agn.id
+  name     = "simple-state"
+
+  items = [
+    {
+      type    = "message"
+      role    = "user"
+      content = "hi"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "Hi! How are you?"
+    },
+    {
+      type    = "message"
+      role    = "user"
+      content = "fine"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "How can I help you?"
+    },
+  ]
+}
+
+resource "testllm_test" "agn_system_prompt" {
+  org_id   = testllm_organization.org.id
+  suite_id = testllm_test_suite.agn.id
+  name     = "system-prompt"
+
+  items = [
+    {
+      type    = "message"
+      role    = "system"
+      content = "You are personal assistant"
+    },
+    {
+      type    = "message"
+      role    = "user"
+      content = "hi"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "Hello! I am here to help!"
+    },
+  ]
+}

--- a/codex.tf
+++ b/codex.tf
@@ -1,0 +1,65 @@
+resource "testllm_test_suite" "codex" {
+  org_id = testllm_organization.org.id
+  name   = "codex"
+}
+
+resource "testllm_test" "codex_simple_hello" {
+  org_id   = testllm_organization.org.id
+  suite_id = testllm_test_suite.codex.id
+  name     = "simple-hello"
+
+  items = [
+    {
+      type        = "message"
+      role        = "developer"
+      content     = ""
+      any_content = true
+    },
+    {
+      type        = "message"
+      role        = "user"
+      content     = ""
+      any_content = true
+    },
+    {
+      type    = "message"
+      role    = "user"
+      content = "hello"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "Hi! How are you?"
+    },
+  ]
+}
+
+resource "testllm_test" "codex_simple_tool_call" {
+  org_id   = testllm_organization.org.id
+  suite_id = testllm_test_suite.codex.id
+  name     = "simple-tool-call"
+
+  items = [
+    {
+      type    = "message"
+      role    = "user"
+      content = "What is the weather in Paris?"
+    },
+    {
+      type      = "function_call"
+      func_name = "get_weather"
+      call_id   = "fc_001"
+      arguments = "{\"location\": \"Paris\"}"
+    },
+    {
+      type    = "function_call_output"
+      call_id = "fc_001"
+      output  = "{\"temperature\": \"18\u00b0C\", \"condition\": \"partly cloudy\"}"
+    },
+    {
+      type    = "message"
+      role    = "assistant"
+      content = "The weather in Paris is 18\u00b0C and partly cloudy."
+    },
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    testllm = {
+      source  = "agynio/testllm"
+      version = "0.2.0"
+    }
+  }
+}
+
+provider "testllm" {
+  host  = var.endpoint
+  token = var.api_token
+}
+
+resource "testllm_organization" "org" {
+  name = var.org_name
+  slug = var.org_slug
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,20 @@
+variable "endpoint" {
+  description = "TestLLM API endpoint URL"
+  type        = string
+}
+
+variable "api_token" {
+  description = "TestLLM API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "org_name" {
+  description = "Organization name"
+  type        = string
+}
+
+variable "org_slug" {
+  description = "Organization slug"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Terraform provider/org config plus agn/codex suites
- map endpoint/api_token variables to provider host/token inputs
- define test items using list syntax per provider schema

## Testing
- terraform fmt -check
- terraform validate

Refs #1