### PR TITLE
fix: align codex simple-hello format

### DIFF
--- a/codex.tf
+++ b/codex.tf
@@ -16,6 +16,12 @@ resource "testllm_test" "codex_simple_hello" {
       any_content = true
     },
     {
+      type        = "message"
+      role        = "user"
+      content     = ""
+      any_content = true
+    },
+    {
       type    = "message"
       role    = "user"
       content = "hello"


### PR DESCRIPTION
## Summary
- add placeholder user message to match Codex CLI ordering

## Testing
- terraform fmt -check
- terraform validate

Refs #7