### PR TITLE
feat: add claude test suite

### DIFF
--- a/claude.tf
+++ b/claude.tf
@@ -1,0 +1,137 @@
+resource "testllm_test_suite" "claude" {
+  org_id   = data.testllm_organization.org.id
+  name     = "claude"
+  protocol = "anthropic"
+}
+
+resource "testllm_test" "claude_simple_hello" {
+  org_id   = data.testllm_organization.org.id
+  suite_id = testllm_test_suite.claude.id
+  name     = "simple-hello"
+
+  items = [
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "hello"
+    },
+    {
+      type    = "anthropic_message"
+      role    = "assistant"
+      content = "Hi! How are you?"
+    },
+  ]
+}
+
+resource "testllm_test" "claude_simple_state" {
+  org_id   = data.testllm_organization.org.id
+  suite_id = testllm_test_suite.claude.id
+  name     = "simple-state"
+
+  items = [
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "hello"
+    },
+    {
+      type    = "anthropic_message"
+      role    = "assistant"
+      content = "Hi! How are you?"
+    },
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "fine"
+    },
+    {
+      type    = "anthropic_message"
+      role    = "assistant"
+      content = "How can I help you?"
+    },
+  ]
+}
+
+resource "testllm_test" "claude_mcp_tools_test" {
+  org_id   = data.testllm_organization.org.id
+  suite_id = testllm_test_suite.claude.id
+  name     = "mcp-tools-test"
+
+  items = [
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "Create an entity called test_project of type project with observation 'A test project', then list files in /test-data"
+    },
+    {
+      type = "anthropic_message"
+      role = "assistant"
+      content_blocks = jsonencode([
+        {
+          type = "tool_use"
+          id   = "tool_mem_001"
+          name = "mcp__memory__create_entities"
+          input = {
+            entities = [
+              {
+                name         = "test_project"
+                entityType   = "project"
+                observations = ["A test project"]
+              }
+            ]
+          }
+        }
+      ])
+    },
+    {
+      type = "anthropic_message"
+      role = "user"
+      content_blocks = jsonencode([
+        {
+          type        = "tool_result"
+          tool_use_id = "tool_mem_001"
+          content = jsonencode({
+            entities = [
+              {
+                name         = "test_project"
+                entityType   = "project"
+                observations = ["A test project"]
+              }
+            ]
+          })
+        }
+      ])
+    },
+    {
+      type = "anthropic_message"
+      role = "assistant"
+      content_blocks = jsonencode([
+        {
+          type = "tool_use"
+          id   = "tool_fs_001"
+          name = "mcp__filesystem__list_directory"
+          input = {
+            path = "/test-data"
+          }
+        }
+      ])
+    },
+    {
+      type = "anthropic_message"
+      role = "user"
+      content_blocks = jsonencode([
+        {
+          type        = "tool_result"
+          tool_use_id = "tool_fs_001"
+          content     = jsonencode({ content = "[FILE] hello.txt" })
+        }
+      ])
+    },
+    {
+      type    = "anthropic_message"
+      role    = "assistant"
+      content = "I've created the entity 'test_project' (type: project) with the observation 'A test project'. The /test-data directory contains one file: hello.txt."
+    },
+  ]
+}
+

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     testllm = {
       source  = "agynio/testllm"
-      version = "0.3.0"
+      version = "0.4.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the claude anthropic suite with simple, stateful, and MCP tool tests
- bump the testllm provider version to support anthropic protocol suites

## Testing
- TF_VAR_api_token=placeholder TF_VAR_org_slug=placeholder terraform validate
- terraform fmt -check

Refs #21