### PR TITLE
test(agn): stabilize agyn wait shell output

### DIFF
--- a/agn.tf
+++ b/agn.tf
@@ -358,12 +358,12 @@ resource "testllm_test" "agn_shell_agyn_thread_create_wait" {
       type      = "function_call"
       func_name = "shell"
       call_id   = "fc_shell_agyn_wait_001"
-      arguments = "{\"command\": \"agyn threads create --organization-id \\\"$AGYN_ORGANIZATION_ID\\\" --add @e2e-agyn-wait-b-fixed --ref e2e-agyn-wait-fixed --send \\\"Please reply with e2e-agyn-wait-sentinel-fixed\\\" --wait 120 && echo ok\", \"timeout\": 150}"
+      arguments = "{\"command\": \"agyn threads create --organization-id \\\"$AGYN_ORGANIZATION_ID\\\" --add @e2e-agyn-wait-b-fixed --ref e2e-agyn-wait-fixed --send \\\"Please reply with e2e-agyn-wait-sentinel-fixed\\\" --wait 120 >/tmp/e2e-agyn-wait.out && echo ok\", \"timeout\": 150}"
     },
     {
       type    = "function_call_output"
       call_id = "fc_shell_agyn_wait_001"
-      output  = "{\"exit_code\":0,\"stdout\":\"from: agent\\nAgent B received the agyn wait check-in.\\nok\\n\",\"stderr\":\"\"}"
+      output  = "{\"exit_code\":0,\"stdout\":\"ok\\n\",\"stderr\":\"\"}"
     },
     {
       type    = "message"


### PR DESCRIPTION
Updates the agn TestLLM agyn --wait scenario to redirect agyn stdout and assert only the stable success marker. This still requires agyn threads create --wait to complete successfully, but avoids coupling the scenario to CLI display formatting.